### PR TITLE
Fix: adds empty line at the end of the generated preload.php file

### DIFF
--- a/src/CreateOpcachePreloadFileCommand.php
+++ b/src/CreateOpcachePreloadFileCommand.php
@@ -39,6 +39,7 @@ $preloader->paths(
 
 // Preload!
 $preloader->load();
+
 END;
 
     private const TYPE_API_TOOLS = 'laminas-api-tools';


### PR DESCRIPTION
As noted in https://github.com/laminas/getlaminas.org/pull/50#discussion_r418634269